### PR TITLE
Optimize prover transition evaluations

### DIFF
--- a/src/air/constraints/evaluator.rs
+++ b/src/air/constraints/evaluator.rs
@@ -5,7 +5,11 @@ use lambdaworks_math::{
 };
 
 use super::{boundary::BoundaryConstraints, evaluation_table::ConstraintEvaluationTable};
-use crate::{air::{frame::Frame, trace::TraceTable, AIR}, prover::evaluate_polynomial_on_lde_domain, Domain};
+use crate::{
+    air::{frame::Frame, trace::TraceTable, AIR},
+    prover::evaluate_polynomial_on_lde_domain,
+    Domain,
+};
 use std::iter::zip;
 
 pub struct ConstraintEvaluator<'poly, F: IsFFTField, A: AIR> {
@@ -94,19 +98,20 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
                 domain.blowup_factor,
                 domain.interpolation_domain_size,
                 &domain.coset_offset,
-            ).unwrap();
+            )
+            .unwrap();
             FieldElement::inplace_batch_inverse(&mut evaluations);
             transition_zerofiers_inverse_evaluations.push(evaluations);
-        } 
+        }
 
         let mut degree_adjustments = Vec::new();
         for transition_degree in self.air.context().transition_degrees().iter() {
             let mut transition_adjustment = Vec::new();
             for d in domain.lde_roots_of_unity_coset.iter() {
                 let degree_adjustment = self.air.composition_poly_degree_bound()
-                        - (self.air.context().trace_length * (transition_degree - 1));
+                    - (self.air.context().trace_length * (transition_degree - 1));
                 transition_adjustment.push(d.pow(degree_adjustment));
-            } 
+            }
             degree_adjustments.push(transition_adjustment);
         }
 
@@ -125,8 +130,14 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
             transition_evaluations.push(evaluations.clone());
 
             // TODO: Remove clones
-            let denominators: Vec<_> = transition_zerofiers_inverse_evaluations.iter().map(|zerofier_evals| zerofier_evals[i].clone()).collect();
-            let degree_adjustments: Vec<_> = degree_adjustments.iter().map(|transition_adjustments| transition_adjustments[i].clone()).collect();
+            let denominators: Vec<_> = transition_zerofiers_inverse_evaluations
+                .iter()
+                .map(|zerofier_evals| zerofier_evals[i].clone())
+                .collect();
+            let degree_adjustments: Vec<_> = degree_adjustments
+                .iter()
+                .map(|transition_adjustments| transition_adjustments[i].clone())
+                .collect();
             evaluations = Self::compute_constraint_composition_poly_evaluations(
                 &evaluations,
                 &denominators,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -224,7 +224,7 @@ where
 
     let constraint_evaluations = evaluator.evaluate(
         &round_1_result.lde_trace,
-        &domain,
+        domain,
         transition_coeffs,
         boundary_coeffs,
         &round_1_result.rap_challenges,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -91,7 +91,7 @@ where
     (trees, roots)
 }
 
-fn evaluate_polynomial_on_lde_domain<F>(
+pub fn evaluate_polynomial_on_lde_domain<F>(
     p: &Polynomial<FieldElement<F>>,
     blowup_factor: usize,
     domain_size: usize,
@@ -224,7 +224,7 @@ where
 
     let constraint_evaluations = evaluator.evaluate(
         &round_1_result.lde_trace,
-        &domain.lde_roots_of_unity_coset,
+        &domain,
         transition_coeffs,
         boundary_coeffs,
         &round_1_result.rap_challenges,

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -253,7 +253,7 @@ fn step_2_verify_claimed_composition_polynomial<F: IsFFTField, A: AIR<Field = F>
     );
 
     let divisors = air.transition_divisors();
-   
+
     let mut denominators = Vec::with_capacity(divisors.len());
     for divisor in divisors.iter() {
         denominators.push(divisor.evaluate(&challenges.z));
@@ -263,7 +263,7 @@ fn step_2_verify_claimed_composition_polynomial<F: IsFFTField, A: AIR<Field = F>
     let mut degree_adjustments = Vec::with_capacity(divisors.len());
     for transition_degree in air.context().transition_degrees().iter() {
         let degree_adjustment = air.composition_poly_degree_bound()
-                        - (air.context().trace_length * (transition_degree - 1));
+            - (air.context().trace_length * (transition_degree - 1));
         degree_adjustments.push(challenges.z.pow(degree_adjustment));
     }
     let transition_c_i_evaluations =

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -253,13 +253,25 @@ fn step_2_verify_claimed_composition_polynomial<F: IsFFTField, A: AIR<Field = F>
     );
 
     let divisors = air.transition_divisors();
+   
+    let mut denominators = Vec::with_capacity(divisors.len());
+    for divisor in divisors.iter() {
+        denominators.push(divisor.evaluate(&challenges.z));
+    }
+    FieldElement::inplace_batch_inverse(&mut denominators);
+
+    let mut degree_adjustments = Vec::with_capacity(divisors.len());
+    for transition_degree in air.context().transition_degrees().iter() {
+        let degree_adjustment = air.composition_poly_degree_bound()
+                        - (air.context().trace_length * (transition_degree - 1));
+        degree_adjustments.push(challenges.z.pow(degree_adjustment));
+    }
     let transition_c_i_evaluations =
-        ConstraintEvaluator::compute_constraint_composition_poly_evaluations(
-            air,
+        ConstraintEvaluator::<F, A>::compute_constraint_composition_poly_evaluations(
             &transition_ood_frame_evaluations,
-            &divisors,
+            &denominators,
+            &degree_adjustments,
             &challenges.transition_coeffs,
-            &challenges.z,
         );
 
     let composition_poly_ood_evaluation = &boundary_quotient_ood_evaluation


### PR DESCRIPTION
- Computes outside of the forloop some polynomial evaluations and inverses.
- Change lagrange evaluation to FFT.
- Uses batch inverse.