### PR TITLE
perf: update lambdaworks and use Ruffini in deep composition poly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "91916f0" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "91916f0" }
-lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "91916f0" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
+lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -389,7 +389,6 @@ fn compute_deep_composition_poly<A: AIR, F: IsFFTField>(
     trace_terms_gammas: &[FieldElement<F>],
 ) -> Polynomial<FieldElement<F>> {
     // Compute composition polynomial terms of the deep composition polynomial.
-    let x = Polynomial::new_monomial(FieldElement::one(), 1);
     let h_1 = &round_2_result.composition_poly_even;
     let h_1_z2 = &round_3_result.composition_poly_even_ood_evaluation;
     let h_2 = &round_2_result.composition_poly_odd;
@@ -399,10 +398,12 @@ fn compute_deep_composition_poly<A: AIR, F: IsFFTField>(
     let z_squared = z * z;
 
     // 𝛾 ( H₁ − H₁(z²) ) / ( X − z² )
-    let h_1_term = gamma * (h_1 - h_1_z2) / (&x - &z_squared);
+    let mut h_1_term = gamma * (h_1 - h_1_z2);
+    h_1_term.ruffini_division_inplace(&z_squared);
 
     // 𝛾' ( H₂ − H₂(z²) ) / ( X − z² )
-    let h_2_term = gamma_p * (h_2 - h_2_z2) / (&x - z_squared);
+    let mut h_2_term = gamma_p * (h_2 - h_2_z2);
+    h_2_term.ruffini_division_inplace(&z_squared);
 
     // Get trace evaluations needed for the trace terms of the deep composition polynomial
     let transition_offsets = air.context().transition_offsets;
@@ -429,7 +430,8 @@ fn compute_deep_composition_poly<A: AIR, F: IsFFTField>(
             let t_j_z = evaluations[i].clone();
             // @@@ this can be pre-computed
             let z_shifted = z * primitive_root.pow(*offset);
-            let poly = (t_j - t_j_z) / (&x - z_shifted);
+            let mut poly = t_j - t_j_z;
+            poly.ruffini_division_inplace(&z_shifted);
             trace_terms = trace_terms + poly * elemen_trace_gamma;
         }
     }


### PR DESCRIPTION
Updates lambdaworks dep to use Ruffini division in deep composition polynomials.
The update also includes a few other optimizations, namely the Merkle tree build one.

## Bench results (on M1)

```
CAIRO/fibonacci/10      time:   [59.898 ms 60.048 ms 60.284 ms]
                        change: [-53.124% -52.911% -52.675%] (p = 0.00 < 0.05)
CAIRO/fibonacci/30      time:   [132.44 ms 132.91 ms 133.17 ms]
                        change: [-66.094% -66.001% -65.920%] (p = 0.00 < 0.05)
```
