### PR TITLE
Commit multiple columns using a single Merkle Tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
-lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "5d61e79" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
+lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
-lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "7fa75300" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
+lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs/" }
+sha3 = "0.10.6"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,5 @@ To be added:
 - Grinding
 - Skipping FRI layers
 - Optimizing verifier operations
-- Batch proofs in Merkle trees
 - Range check and Pedersen built-ins
 - Different layouts

--- a/src/fri/fri_commitment.rs
+++ b/src/fri/fri_commitment.rs
@@ -3,7 +3,7 @@ use lambdaworks_math::{
     traits::ByteConversion,
 };
 
-use super::HASHER;
+use super::FriHasher;
 pub use super::{FriMerkleTree, Polynomial};
 
 #[derive(Clone)]
@@ -21,7 +21,7 @@ where
 {
     pub fn new(poly: Polynomial<FieldElement<F>>, domain: &[FieldElement<F>]) -> Self {
         let evaluation = poly.evaluate_slice(domain);
-        let merkle_tree = FriMerkleTree::build(&evaluation, HASHER);
+        let merkle_tree = FriMerkleTree::build(&evaluation, FriHasher::new());
 
         Self {
             poly,

--- a/src/fri/fri_commitment.rs
+++ b/src/fri/fri_commitment.rs
@@ -11,7 +11,7 @@ pub struct FriLayer<F: IsField> {
     pub poly: Polynomial<FieldElement<F>>,
     pub domain: Vec<FieldElement<F>>,
     pub evaluation: Vec<FieldElement<F>>,
-    pub merkle_tree: FriMerkleTree<F>,
+    pub merkle_tree: FriMerkleTree,
 }
 
 impl<F> FriLayer<F>
@@ -21,7 +21,7 @@ where
 {
     pub fn new(poly: Polynomial<FieldElement<F>>, domain: &[FieldElement<F>]) -> Self {
         let evaluation = poly.evaluate_slice(domain);
-        let merkle_tree = FriMerkleTree::build(&evaluation, Box::new(HASHER));
+        let merkle_tree = FriMerkleTree::build(&evaluation, HASHER);
 
         Self {
             poly,

--- a/src/fri/fri_commitment.rs
+++ b/src/fri/fri_commitment.rs
@@ -3,15 +3,18 @@ use lambdaworks_math::{
     traits::ByteConversion,
 };
 
-use super::FriHasher;
 pub use super::{FriMerkleTree, Polynomial};
 
 #[derive(Clone)]
-pub struct FriLayer<F: IsField> {
+pub struct FriLayer<F>
+where
+    F: IsField,
+    FieldElement<F>: ByteConversion
+{
     pub poly: Polynomial<FieldElement<F>>,
     pub domain: Vec<FieldElement<F>>,
     pub evaluation: Vec<FieldElement<F>>,
-    pub merkle_tree: FriMerkleTree,
+    pub merkle_tree: FriMerkleTree<F>,
 }
 
 impl<F> FriLayer<F>
@@ -21,7 +24,7 @@ where
 {
     pub fn new(poly: Polynomial<FieldElement<F>>, domain: &[FieldElement<F>]) -> Self {
         let evaluation = poly.evaluate_slice(domain);
-        let merkle_tree = FriMerkleTree::build(&evaluation, FriHasher::new());
+        let merkle_tree = FriMerkleTree::build(&evaluation);
 
         Self {
             poly,

--- a/src/fri/fri_commitment.rs
+++ b/src/fri/fri_commitment.rs
@@ -13,7 +13,7 @@ use lambdaworks_fft::polynomial::FFTPoly;
 pub struct FriLayer<F>
 where
     F: IsField,
-    FieldElement<F>: ByteConversion
+    FieldElement<F>: ByteConversion,
 {
     pub poly: Polynomial<FieldElement<F>>,
     pub evaluation: Vec<FieldElement<F>>,

--- a/src/fri/fri_decommit.rs
+++ b/src/fri/fri_decommit.rs
@@ -5,8 +5,8 @@ use lambdaworks_math::field::traits::IsField;
 
 #[derive(Debug, Clone)]
 pub struct FriDecommitment<F: IsField> {
-    pub layers_auth_paths_sym: Vec<Proof<F>>,
+    pub layers_auth_paths_sym: Vec<Proof>,
     pub layers_evaluations_sym: Vec<FieldElement<F>>,
     pub first_layer_evaluation: FieldElement<F>,
-    pub first_layer_auth_path: Proof<F>,
+    pub first_layer_auth_path: Proof,
 }

--- a/src/fri/fri_decommit.rs
+++ b/src/fri/fri_decommit.rs
@@ -3,10 +3,12 @@ use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::IsField;
 
+use super::FriCommitment;
+
 #[derive(Debug, Clone)]
 pub struct FriDecommitment<F: IsField> {
-    pub layers_auth_paths_sym: Vec<Proof>,
+    pub layers_auth_paths_sym: Vec<Proof<FriCommitment>>,
     pub layers_evaluations_sym: Vec<FieldElement<F>>,
     pub first_layer_evaluation: FieldElement<F>,
-    pub first_layer_auth_path: Proof,
+    pub first_layer_auth_path: Proof<FriCommitment>,
 }

--- a/src/fri/fri_decommit.rs
+++ b/src/fri/fri_decommit.rs
@@ -3,12 +3,12 @@ use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::element::FieldElement;
 use lambdaworks_math::field::traits::IsField;
 
-use super::FriCommitment;
+use super::Commitment;
 
 #[derive(Debug, Clone)]
 pub struct FriDecommitment<F: IsField> {
-    pub layers_auth_paths_sym: Vec<Proof<FriCommitment>>,
+    pub layers_auth_paths_sym: Vec<Proof<Commitment>>,
     pub layers_evaluations_sym: Vec<FieldElement<F>>,
     pub first_layer_evaluation: FieldElement<F>,
-    pub first_layer_auth_path: Proof<FriCommitment>,
+    pub first_layer_auth_path: Proof<Commitment>,
 }

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -6,7 +6,7 @@ use crate::fri::fri_commitment::FriLayer;
 use crate::{transcript_to_field, transcript_to_usize, Domain};
 
 pub use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
-use lambdaworks_crypto::hash::sha3::FieldElementSha3Hasher;
+use lambdaworks_crypto::merkle_tree::merkle::FieldElementBackend;
 pub use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_math::field::traits::{IsFFTField, IsField};
 use lambdaworks_math::traits::ByteConversion;
@@ -19,8 +19,8 @@ use self::fri_decommit::FriDecommitment;
 use self::fri_functions::{fold_polynomial, next_domain};
 
 pub type FriCommitment = [u8; 32];
-pub type FriMerkleTree = MerkleTree<FriCommitment>;
-pub type FriHasher<F> = FieldElementSha3Hasher<F>;
+pub type FriMerkleBackend<F> = FieldElementBackend<F>;
+pub type FriMerkleTree<F> = MerkleTree<FriMerkleBackend<F>>;
 
 pub fn fri_commit_phase<F: IsField, T: Transcript>(
     number_layers: usize,

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -3,10 +3,9 @@ pub mod fri_decommit;
 mod fri_functions;
 use crate::air::traits::AIR;
 use crate::fri::fri_commitment::FriLayer;
-use crate::{transcript_to_field, transcript_to_usize, Domain};
+use crate::{transcript_to_field, transcript_to_usize, Domain, StarkProverBackend};
 
 pub use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
-use lambdaworks_crypto::merkle_tree::merkle::FieldElementBackend;
 pub use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_math::field::traits::{IsFFTField, IsField};
 use lambdaworks_math::traits::ByteConversion;
@@ -18,9 +17,9 @@ pub use lambdaworks_math::{
 use self::fri_decommit::FriDecommitment;
 use self::fri_functions::{fold_polynomial, next_domain};
 
-pub type FriCommitment = [u8; 32];
-pub type FriMerkleBackend<F> = FieldElementBackend<F>;
-pub type FriMerkleTree<F> = MerkleTree<FriMerkleBackend<F>>;
+pub type Commitment = [u8; 32];
+pub type FriMerkleBackend<F> = StarkProverBackend<F>;
+pub type FriMerkleTree<F> = MerkleTree<StarkProverBackend<F>>;
 
 pub fn fri_commit_phase<F: IsField, T: Transcript>(
     number_layers: usize,

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -4,9 +4,9 @@ mod fri_functions;
 use crate::air::traits::AIR;
 use crate::fri::fri_commitment::FriLayer;
 use crate::{transcript_to_field, transcript_to_usize, Domain};
-use lambdaworks_crypto::hash::sha3::Sha3Hasher;
 
 pub use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
+use lambdaworks_crypto::hash::sha3::FieldElementSha3Hasher;
 pub use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_math::field::traits::{IsFFTField, IsField};
 use lambdaworks_math::traits::ByteConversion;
@@ -18,8 +18,9 @@ pub use lambdaworks_math::{
 use self::fri_decommit::FriDecommitment;
 use self::fri_functions::{fold_polynomial, next_domain};
 
-pub type FriMerkleTree = MerkleTree;
-pub(crate) const HASHER: Sha3Hasher = Sha3Hasher::new();
+pub type FriCommitment = [u8; 32];
+pub type FriMerkleTree = MerkleTree<FriCommitment>;
+pub type FriHasher<F> = FieldElementSha3Hasher<F>;
 
 pub fn fri_commit_phase<F: IsField, T: Transcript>(
     number_layers: usize,

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -3,9 +3,10 @@ pub mod fri_decommit;
 mod fri_functions;
 use crate::air::traits::AIR;
 use crate::fri::fri_commitment::FriLayer;
-use crate::{transcript_to_field, transcript_to_usize, StarkProverBackend};
+use crate::{transcript_to_field, transcript_to_usize};
 
 pub use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
+use lambdaworks_crypto::merkle_tree::merkle::FieldElementBackend;
 pub use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_math::field::traits::{IsFFTField, IsField};
 use lambdaworks_math::traits::ByteConversion;
@@ -18,8 +19,8 @@ use self::fri_decommit::FriDecommitment;
 use self::fri_functions::fold_polynomial;
 
 pub type Commitment = [u8; 32];
-pub type FriMerkleBackend<F> = StarkProverBackend<F>;
-pub type FriMerkleTree<F> = MerkleTree<StarkProverBackend<F>>;
+pub type FriMerkleBackend<F> = FieldElementBackend<F>;
+pub type FriMerkleTree<F> = MerkleTree<FieldElementBackend<F>>;
 
 pub fn fri_commit_phase<F: IsField + IsFFTField, T: Transcript>(
     number_layers: usize,

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -18,7 +18,7 @@ pub use lambdaworks_math::{
 use self::fri_decommit::FriDecommitment;
 use self::fri_functions::{fold_polynomial, next_domain};
 
-pub type FriMerkleTree<F> = MerkleTree<F>;
+pub type FriMerkleTree = MerkleTree;
 pub(crate) const HASHER: Sha3Hasher = Sha3Hasher::new();
 
 pub fn fri_commit_phase<F: IsField, T: Transcript>(
@@ -35,7 +35,7 @@ where
     fri_layer_list.push(current_layer.clone());
 
     // >>>> Send commitment: [p₀]
-    transcript.append(&current_layer.merkle_tree.root.to_bytes_be());
+    transcript.append(&current_layer.merkle_tree.root);
 
     for _ in 1..number_layers {
         // <<<< Receive challenge 𝜁ₖ₋₁
@@ -48,7 +48,7 @@ where
         fri_layer_list.push(current_layer.clone());
 
         // >>>> Send commitment: [pₖ]
-        transcript.append(&current_layer.merkle_tree.root.to_bytes_be());
+        transcript.append(&current_layer.merkle_tree.root);
     }
 
     // <<<< Receive challenge: 𝜁ₙ₋₁

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,45 +115,6 @@ impl<F: IsFFTField> Domain<F> {
     }
 }
 
-#[derive(Clone)]
-pub struct StarkProverBackend<F> {
-    phantom: PhantomData<F>,
-}
-
-impl<F> Default for StarkProverBackend<F> {
-    fn default() -> Self {
-        Self {
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<F> IsMerkleTreeBackend for StarkProverBackend<F>
-where
-    F: IsField,
-    FieldElement<F>: ByteConversion,
-{
-    type Node = [u8; 32];
-    type Data = FieldElement<F>;
-
-    fn hash_data(&self, input: &FieldElement<F>) -> [u8; 32] {
-        let mut hasher = Sha3_256::new();
-        hasher.update(input.to_bytes_be());
-        let mut result_hash = [0_u8; 32];
-        result_hash.copy_from_slice(&hasher.finalize());
-        result_hash
-    }
-
-    fn hash_new_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
-        let mut hasher = Sha3_256::new();
-        hasher.update(left);
-        hasher.update(right);
-        let mut result_hash = [0_u8; 32];
-        result_hash.copy_from_slice(&hasher.finalize());
-        result_hash
-    }
-}
-
 /// A Merkle tree backend for vectors of field elements.
 /// This is used by the Stark prover to commit to
 /// multiple trace columns using a single Merkle tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,9 @@ where
     }
 }
 
+/// A Merkle tree backend for vectors of field elements.
+/// This is used by the Stark prover to commit to
+/// multiple trace columns using a single Merkle tree.
 #[derive(Clone)]
 pub struct BatchStarkProverBackend<F> {
     phantom: PhantomData<F>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,18 @@ pub mod verifier;
 use std::marker::PhantomData;
 
 use air::traits::AIR;
-use lambdaworks_crypto::{fiat_shamir::transcript::Transcript, merkle_tree::traits::IsMerkleTreeBackend};
+use lambdaworks_crypto::{
+    fiat_shamir::transcript::Transcript, merkle_tree::traits::IsMerkleTreeBackend,
+};
 use lambdaworks_fft::roots_of_unity::get_powers_of_primitive_root_coset;
-use lambdaworks_math::{field::{
-    element::FieldElement,
-    fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
-    traits::{IsFFTField, IsField},
-}, traits::ByteConversion};
+use lambdaworks_math::{
+    field::{
+        element::FieldElement,
+        fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+        traits::{IsFFTField, IsField},
+    },
+    traits::ByteConversion,
+};
 use sha3::{Digest, Sha3_256};
 
 pub struct ProofConfig {
@@ -189,4 +194,3 @@ where
         result_hash
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,17 @@ pub mod proof;
 pub mod prover;
 pub mod verifier;
 
+use std::marker::PhantomData;
+
 use air::traits::AIR;
-use lambdaworks_crypto::fiat_shamir::transcript::Transcript;
+use lambdaworks_crypto::{fiat_shamir::transcript::Transcript, merkle_tree::traits::IsMerkleTreeBackend};
 use lambdaworks_fft::roots_of_unity::get_powers_of_primitive_root_coset;
-use lambdaworks_math::field::{
+use lambdaworks_math::{field::{
     element::FieldElement,
     fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
     traits::{IsFFTField, IsField},
-};
+}, traits::ByteConversion};
+use sha3::{Digest, Sha3_256};
 
 pub struct ProofConfig {
     pub count_queries: usize,
@@ -106,3 +109,84 @@ impl<F: IsFFTField> Domain<F> {
         }
     }
 }
+
+#[derive(Clone)]
+pub struct StarkProverBackend<F> {
+    phantom: PhantomData<F>,
+}
+
+impl<F> Default for StarkProverBackend<F> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F> IsMerkleTreeBackend for StarkProverBackend<F>
+where
+    F: IsField,
+    FieldElement<F>: ByteConversion,
+{
+    type Node = [u8; 32];
+    type Data = FieldElement<F>;
+
+    fn hash_data(&self, input: &FieldElement<F>) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        hasher.update(input.to_bytes_be());
+        let mut result_hash = [0_u8; 32];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+
+    fn hash_new_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        hasher.update(left);
+        hasher.update(right);
+        let mut result_hash = [0_u8; 32];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+}
+
+#[derive(Clone)]
+pub struct BatchStarkProverBackend<F> {
+    phantom: PhantomData<F>,
+}
+
+impl<F> Default for BatchStarkProverBackend<F> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F> IsMerkleTreeBackend for BatchStarkProverBackend<F>
+where
+    F: IsField,
+    FieldElement<F>: ByteConversion,
+{
+    type Node = [u8; 32];
+    type Data = Vec<FieldElement<F>>;
+
+    fn hash_data(&self, input: &Vec<FieldElement<F>>) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        for element in input.iter() {
+            hasher.update(element.to_bytes_be());
+        }
+        let mut result_hash = [0_u8; 32];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+
+    fn hash_new_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        hasher.update(left);
+        hasher.update(right);
+        let mut result_hash = [0_u8; 32];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+}
+

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,15 +1,15 @@
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
-use crate::{air::frame::Frame, fri::fri_decommit::FriDecommitment};
+use crate::{air::frame::Frame, fri::{fri_decommit::FriDecommitment, FriCommitment}};
 
 #[derive(Debug, Clone)]
 pub struct DeepPolynomialOpenings<F: IsFFTField> {
-    pub lde_composition_poly_even_proof: Proof,
+    pub lde_composition_poly_even_proof: Proof<FriCommitment>,
     pub lde_composition_poly_even_evaluation: FieldElement<F>,
-    pub lde_composition_poly_odd_proof: Proof,
+    pub lde_composition_poly_odd_proof: Proof<FriCommitment>,
     pub lde_composition_poly_odd_evaluation: FieldElement<F>,
-    pub lde_trace_merkle_proofs: Vec<Proof>,
+    pub lde_trace_merkle_proofs: Vec<Proof<FriCommitment>>,
     pub lde_trace_evaluations: Vec<FieldElement<F>>,
 }
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,7 +1,10 @@
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
-use crate::{air::frame::Frame, fri::{fri_decommit::FriDecommitment, Commitment}};
+use crate::{
+    air::frame::Frame,
+    fri::{fri_decommit::FriDecommitment, Commitment},
+};
 
 #[derive(Debug, Clone)]
 pub struct DeepPolynomialOpenings<F: IsFFTField> {

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,5 +1,3 @@
-use std::os::unix::process::CommandExt;
-
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,15 +1,16 @@
+use std::os::unix::process::CommandExt;
+
 use lambdaworks_crypto::merkle_tree::proof::Proof;
 use lambdaworks_math::field::{element::FieldElement, traits::IsFFTField};
 
-use crate::{air::frame::Frame, fri::{fri_decommit::FriDecommitment, FriCommitment}};
+use crate::{air::frame::Frame, fri::{fri_decommit::FriDecommitment, Commitment}};
 
 #[derive(Debug, Clone)]
 pub struct DeepPolynomialOpenings<F: IsFFTField> {
-    pub lde_composition_poly_even_proof: Proof<FriCommitment>,
+    pub lde_composition_poly_proof: Proof<Commitment>,
     pub lde_composition_poly_even_evaluation: FieldElement<F>,
-    pub lde_composition_poly_odd_proof: Proof<FriCommitment>,
     pub lde_composition_poly_odd_evaluation: FieldElement<F>,
-    pub lde_trace_merkle_proofs: Vec<Proof<FriCommitment>>,
+    pub lde_trace_merkle_proofs: Vec<Proof<Commitment>>,
     pub lde_trace_evaluations: Vec<FieldElement<F>>,
 }
 
@@ -17,19 +18,17 @@ pub struct DeepPolynomialOpenings<F: IsFFTField> {
 pub struct StarkProof<F: IsFFTField> {
     // Commitments of the trace columns
     // [tⱼ]
-    pub lde_trace_merkle_roots: Vec<[u8; 32]>,
+    pub lde_trace_merkle_roots: Vec<Commitment>,
     // tⱼ(zgᵏ)
     pub trace_ood_frame_evaluations: Frame<F>,
-    // [H₁]
-    pub composition_poly_even_root: [u8; 32],
+    // [H₁] and [H₂]
+    pub composition_poly_root: Commitment,
     // H₁(z²)
     pub composition_poly_even_ood_evaluation: FieldElement<F>,
-    // [H₂]
-    pub composition_poly_odd_root:[u8; 32], 
     // H₂(z²)
     pub composition_poly_odd_ood_evaluation: FieldElement<F>,
     // [pₖ]
-    pub fri_layers_merkle_roots: Vec<[u8; 32]>,
+    pub fri_layers_merkle_roots: Vec<Commitment>,
     // pₙ
     pub fri_last_value: FieldElement<F>,
     // Open(p₀(D₀), 𝜐ₛ), Opwn(pₖ(Dₖ), −𝜐ₛ^(2ᵏ))

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -5,11 +5,11 @@ use crate::{air::frame::Frame, fri::fri_decommit::FriDecommitment};
 
 #[derive(Debug, Clone)]
 pub struct DeepPolynomialOpenings<F: IsFFTField> {
-    pub lde_composition_poly_even_proof: Proof<F>,
+    pub lde_composition_poly_even_proof: Proof,
     pub lde_composition_poly_even_evaluation: FieldElement<F>,
-    pub lde_composition_poly_odd_proof: Proof<F>,
+    pub lde_composition_poly_odd_proof: Proof,
     pub lde_composition_poly_odd_evaluation: FieldElement<F>,
-    pub lde_trace_merkle_proofs: Vec<Proof<F>>,
+    pub lde_trace_merkle_proofs: Vec<Proof>,
     pub lde_trace_evaluations: Vec<FieldElement<F>>,
 }
 
@@ -17,19 +17,19 @@ pub struct DeepPolynomialOpenings<F: IsFFTField> {
 pub struct StarkProof<F: IsFFTField> {
     // Commitments of the trace columns
     // [tⱼ]
-    pub lde_trace_merkle_roots: Vec<FieldElement<F>>,
+    pub lde_trace_merkle_roots: Vec<[u8; 32]>,
     // tⱼ(zgᵏ)
     pub trace_ood_frame_evaluations: Frame<F>,
     // [H₁]
-    pub composition_poly_even_root: FieldElement<F>,
+    pub composition_poly_even_root: [u8; 32],
     // H₁(z²)
     pub composition_poly_even_ood_evaluation: FieldElement<F>,
     // [H₂]
-    pub composition_poly_odd_root: FieldElement<F>,
+    pub composition_poly_odd_root:[u8; 32], 
     // H₂(z²)
     pub composition_poly_odd_ood_evaluation: FieldElement<F>,
     // [pₖ]
-    pub fri_layers_merkle_roots: Vec<FieldElement<F>>,
+    pub fri_layers_merkle_roots: Vec<[u8; 32]>,
     // pₙ
     pub fri_last_value: FieldElement<F>,
     // Open(p₀(D₀), 𝜐ₛ), Opwn(pₖ(Dₖ), −𝜐ₛ^(2ᵏ))

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -366,7 +366,7 @@ where
 
     let fri_layers_merkle_roots: Vec<_> = fri_layers
         .iter()
-        .map(|layer| layer.merkle_tree.root.clone())
+        .map(|layer| layer.merkle_tree.root)
         .collect();
 
     let deep_poly_openings =

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -258,7 +258,8 @@ where
         .zip(&lde_composition_poly_odd_evaluations)
         .map(|(a, b)| vec![a.clone(), b.clone()])
         .collect();
-    let (composition_poly_merkle_tree, composition_poly_root) = batch_commit(&composition_poly_evaluations);
+    let (composition_poly_merkle_tree, composition_poly_root) =
+        batch_commit(&composition_poly_evaluations);
 
     Round2 {
         composition_poly_even,
@@ -483,6 +484,7 @@ where
         .iter()
         .map(|tree| tree.get_proof_by_pos(index).unwrap())
         .collect();
+
     let lde_trace_evaluations = round_1_result.lde_trace.get_row(index).to_vec();
 
     DeepPolynomialOpenings {

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -6,9 +6,9 @@ use super::{
 use crate::{
     air::traits::AIR,
     batch_sample_challenges,
-    fri::{fri_decommit::FriDecommitment, fri_query_phase, Commitment, FriMerkleTree},
+    fri::{fri_decommit::FriDecommitment, fri_query_phase, Commitment},
     proof::{DeepPolynomialOpenings, StarkProof},
-    transcript_to_field, BatchStarkProverBackend, Domain, StarkProverBackend,
+    transcript_to_field, BatchStarkProverBackend, Domain,
 };
 #[cfg(not(feature = "test_fiat_shamir"))]
 use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
@@ -42,7 +42,7 @@ where
     trace_polys: Vec<Polynomial<FieldElement<F>>>,
     lde_trace: TraceTable<F>,
     lde_trace_merkle_trees: Vec<MerkleTree<BatchStarkProverBackend<F>>>,
-    lde_trace_merkle_roots: Vec<[u8; 32]>,
+    lde_trace_merkle_roots: Vec<Commitment>,
     rap_challenges: A::RAPChallenges,
 }
 
@@ -67,7 +67,7 @@ struct Round3<F: IsFFTField> {
 
 struct Round4<F: IsFFTField> {
     fri_last_value: FieldElement<F>,
-    fri_layers_merkle_roots: Vec<[u8; 32]>,
+    fri_layers_merkle_roots: Vec<Commitment>,
     deep_poly_openings: DeepPolynomialOpenings<F>,
     query_list: Vec<FriDecommitment<F>>,
 }
@@ -173,7 +173,7 @@ where
 {
     let main_trace = air.build_main_trace(raw_trace, public_input)?;
 
-    let (mut trace_polys, mut evaluations, mut main_merkle_tree, mut main_merkle_root) =
+    let (mut trace_polys, mut evaluations, main_merkle_tree, main_merkle_root) =
         interpolate_and_commit(&main_trace, domain, transcript);
 
     let rap_challenges = air.build_rap_challenges(transcript);
@@ -264,8 +264,8 @@ where
     Round2 {
         composition_poly_even,
         lde_composition_poly_even_evaluations,
-        composition_poly_merkle_tree: composition_poly_merkle_tree,
-        composition_poly_root: composition_poly_root,
+        composition_poly_merkle_tree,
+        composition_poly_root,
         composition_poly_odd,
         lde_composition_poly_odd_evaluations,
     }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -3,7 +3,10 @@ use super::{
     sample_z_ood,
 };
 use crate::{
-    air::traits::AIR, batch_sample_challenges, fri::{FriMerkleBackend, Commitment}, proof::StarkProof,
+    air::traits::AIR,
+    batch_sample_challenges,
+    fri::{Commitment, FriMerkleBackend},
+    proof::StarkProof,
     transcript_to_field, transcript_to_usize, BatchStarkProverBackend, Domain,
 };
 #[cfg(not(feature = "test_fiat_shamir"))]
@@ -345,7 +348,8 @@ where
         .zip(&proof.deep_poly_openings.lde_trace_merkle_proofs)
         .zip(lde_trace_evaluations)
     {
-        result &= merkle_proof.verify::<BatchStarkProverBackend<F>>(merkle_root, iota_0, &evaluation);
+        result &=
+            merkle_proof.verify::<BatchStarkProverBackend<F>>(merkle_root, iota_0, &evaluation);
     }
 
     // DEEP consistency check

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -304,6 +304,7 @@ where
 }
 
 fn step_4_verify_deep_composition_polynomial<F: IsFFTField, A: AIR<Field = F>>(
+    air: &A,
     proof: &StarkProof<F>,
     domain: &Domain<F>,
     challenges: &Challenges<F, A>,
@@ -331,9 +332,11 @@ where
         .lde_composition_poly_proof
         .verify::<BatchStarkProverBackend<F>>(&proof.composition_poly_root, iota_0, &evaluations);
 
+    let num_main_columns = air.context().trace_columns - air.number_auxiliary_rap_columns();
+
     let lde_trace_evaluations = vec![
-        proof.deep_poly_openings.lde_trace_evaluations[..34].to_vec(),
-        proof.deep_poly_openings.lde_trace_evaluations[34..].to_vec(),
+        proof.deep_poly_openings.lde_trace_evaluations[..num_main_columns].to_vec(),
+        proof.deep_poly_openings.lde_trace_evaluations[num_main_columns..].to_vec(),
     ];
     // Verify openings Open(tⱼ(D_LDE), 𝜐₀)
     for ((merkle_root, merkle_proof), evaluation) in proof
@@ -494,5 +497,5 @@ where
         return false;
     }
 
-    step_4_verify_deep_composition_polynomial(proof, &domain, &challenges)
+    step_4_verify_deep_composition_polynomial(air, proof, &domain, &challenges)
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -3,7 +3,7 @@ use super::{
     sample_z_ood,
 };
 use crate::{
-    air::traits::AIR, batch_sample_challenges, fri::FriMerkleBackend, proof::StarkProof,
+    air::traits::AIR, batch_sample_challenges, fri::{FriMerkleBackend, Commitment}, proof::StarkProof,
     transcript_to_field, transcript_to_usize, BatchStarkProverBackend, Domain,
 };
 #[cfg(not(feature = "test_fiat_shamir"))]
@@ -333,11 +333,11 @@ where
         .verify::<BatchStarkProverBackend<F>>(&proof.composition_poly_root, iota_0, &evaluations);
 
     let num_main_columns = air.context().trace_columns - air.number_auxiliary_rap_columns();
-
     let lde_trace_evaluations = vec![
         proof.deep_poly_openings.lde_trace_evaluations[..num_main_columns].to_vec(),
         proof.deep_poly_openings.lde_trace_evaluations[num_main_columns..].to_vec(),
     ];
+
     // Verify openings Open(tⱼ(D_LDE), 𝜐₀)
     for ((merkle_root, merkle_proof), evaluation) in proof
         .lde_trace_merkle_roots
@@ -360,7 +360,7 @@ where
 
 fn verify_query_and_sym_openings<F: IsField + IsFFTField, A: AIR<Field = F>>(
     air: &A,
-    fri_layers_merkle_roots: &[[u8; 32]],
+    fri_layers_merkle_roots: &[Commitment],
     fri_last_value: &FieldElement<F>,
     zetas: &[FieldElement<F>],
     iota: usize,


### PR DESCRIPTION
This PR adds the following:
1. Use a modified version of Merkle trees that don't hash back to Field Elements and builds the entire tree using bytes.
2. Instead of building a Merkle tree for each column of the RAP, use a single Merkle tree for the trace columns of the main part of the RAP another Merkle tree for the second part. The data of each leaf of these merkle trees are the vectors of evaluations of all the polynomials involved.

There are two merkle trees for each part of the RAP because the prover needs to commit to the first ones before getting the RAP challenges from the verifier. Improvements on this are left for another PR.

```
Benchmarking CAIRO/fibonacci/10: Collecting 10 samples in estimated 31.762 s (99
CAIRO/fibonacci/10      time:   [31.787 ms 32.771 ms 34.208 ms]
                        change: [-42.359% -40.011% -37.434%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking CAIRO/fibonacci/30: Collecting 10 samples in estimated 32.952 s (44
CAIRO/fibonacci/30      time:   [67.688 ms 68.215 ms 69.366 ms]
                        change: [-38.890% -36.275% -33.590%] (p = 0.00 < 0.05)
                        Performance has improved.

```