### PR TITLE
fft module of lambdaworks moved inside math

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
-lambdaworks-fft = { git = "https://github.com/lambdaclass/lambdaworks", rev = "133ffb3" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "ad14091" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "ad14091" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/src/air/constraints/evaluation_table.rs
+++ b/src/air/constraints/evaluation_table.rs
@@ -1,4 +1,4 @@
-use lambdaworks_fft::polynomial::FFTPoly;
+use lambdaworks_math::fft::polynomial::FFTPoly;
 use lambdaworks_math::{
     field::{
         element::FieldElement,

--- a/src/air/constraints/evaluator.rs
+++ b/src/air/constraints/evaluator.rs
@@ -1,4 +1,4 @@
-use lambdaworks_fft::roots_of_unity::get_powers_of_primitive_root_coset;
+use lambdaworks_math::fft::roots_of_unity::get_powers_of_primitive_root_coset;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,

--- a/src/air/debug.rs
+++ b/src/air/debug.rs
@@ -1,4 +1,4 @@
-use lambdaworks_fft::polynomial::FFTPoly;
+use lambdaworks_math::fft::polynomial::FFTPoly;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,

--- a/src/air/trace.rs
+++ b/src/air/trace.rs
@@ -1,5 +1,5 @@
-use lambdaworks_fft::errors::FFTError;
-use lambdaworks_fft::polynomial::FFTPoly;
+use lambdaworks_math::fft::errors::FFTError;
+use lambdaworks_math::fft::polynomial::FFTPoly;
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,

--- a/src/fri/fri_commitment.rs
+++ b/src/fri/fri_commitment.rs
@@ -7,7 +7,7 @@ use lambdaworks_math::{
 };
 
 pub use super::{FriMerkleTree, Polynomial};
-use lambdaworks_fft::polynomial::FFTPoly;
+use lambdaworks_math::fft::polynomial::FFTPoly;
 
 #[derive(Clone)]
 pub struct FriLayer<F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use air::traits::AIR;
 use lambdaworks_crypto::{
     fiat_shamir::transcript::Transcript, merkle_tree::traits::IsMerkleTreeBackend,
 };
-use lambdaworks_fft::roots_of_unity::get_powers_of_primitive_root_coset;
+use lambdaworks_math::fft::roots_of_unity::get_powers_of_primitive_root_coset;
 use lambdaworks_math::{
     field::{
         element::FieldElement,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -17,7 +17,7 @@ use lambdaworks_crypto::{fiat_shamir::transcript::Transcript, merkle_tree::merkl
 #[cfg(feature = "test_fiat_shamir")]
 use lambdaworks_crypto::fiat_shamir::test_transcript::TestTranscript;
 
-use lambdaworks_fft::{errors::FFTError, polynomial::FFTPoly};
+use lambdaworks_math::fft::{errors::FFTError, polynomial::FFTPoly};
 use lambdaworks_math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,


### PR DESCRIPTION
The fft module of lambdaworks was moved inside math module.

This PR updates lambdaworks rev version and dependencies of fft.