### PR TITLE
Add Dockerfile to compile CairoPrograms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: test clippy
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 test:
 	cargo test
@@ -8,3 +9,9 @@ clippy:
 
 build_metal:
 	cargo b --features metal --release
+
+docker_build_cairo_compiler:
+	docker build -f cairo_compile.Dockerfile -t cairo .	
+	
+docker_compile_cairo:
+	docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(OUTPUT)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ To be added:
 - Optimizing verifier operations
 - Range check and Pedersen built-ins
 - Different layouts
+
+## Compiling Cairo Programs to prove
+
+You can compile program using `cairo-compile`, which requires `python3.9` and `cairo-lang`
+
+As an alternative, you can use the `Dockerfile` provided. 
+
+Build it with:
+
+`make docker_build_cairo_compiler`
+
+and compile programs with:
+
+`make docker_compile_cairo PROGRAM=program.cairo OUTPUT=program.json`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To be added:
 
 ## Compiling Cairo Programs to prove
 
-You can compile program using `cairo-compile`, which requires `python3.9` and `cairo-lang`
+You can compile a program using `cairo-compile`, which requires `python3.9` and `cairo-lang`
 
 As an alternative, you can use the `Dockerfile` provided. 
 

--- a/cairo_compile.Dockerfile
+++ b/cairo_compile.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends g++ python3.9 libgmp3-dev && \
+  pip install ecdsa==0.18.0 \
+  bitarray==2.7.3 \
+  fastecdsa==2.2.3 \
+  sympy==1.11.1 \
+  typeguard==2.13.3 \
+  cairo-lang==0.11.0
+
+CMD ["cairo-compile"]

--- a/cairo_compile.Dockerfile
+++ b/cairo_compile.Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-slim
 WORKDIR /app
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends g++ python3.9 libgmp3-dev && \
+  apt-get install -y --no-install-recommends g++ libgmp3-dev && \
   pip install ecdsa==0.18.0 \
   bitarray==2.7.3 \
   fastecdsa==2.2.3 \


### PR DESCRIPTION
Add Dockerfile to compile CairoPrograms

This is useful to help users to generate the compiled versions of the programs to then prove with the prover