### PR TITLE
Run with CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: test clippy
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+run:
+	cargo run --release $(PATH)
+	
 test:
 	cargo test
 
@@ -9,5 +13,8 @@ clippy:
 build_metal:
 	cargo b --features metal --release
 
-run:
-	cargo run --release $(PATH)
+docker_build_cairo_compiler:
+	docker build -f cairo_compile.Dockerfile -t cairo .	
+	
+docker_compile_cairo:
+	docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+CC=gcc
+
 .PHONY: test clippy
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-run:
-	cargo run --release $(PATH)
+build: 
+	cargo build --release
+
+run: build
+	cargo run --release $(PROGRAM_PATH)
 	
 test:
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,18 @@ docker_build_cairo_compiler:
 docker_compile_cairo:
 	docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(OUTPUT)
 
-docker_compile_and_run:
+target/release/lambdaworks-stark: 
+	cargo build --release
+	
+docker_compile_and_run: target/release/lambdaworks-stark
 	@echo "Compiling program with docker"
 	@docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(PROGRAM).json
 	@echo "Compiling done"
 	@cargo run --quiet --release $(PROGRAM).json 
 	@rm $(PROGRAM).json
 
-compile_and_run:
+compile_and_run: target/release/lambdaworks-stark
+	cargo build --release
 	@echo "Compiling program with cairo-compile"
 	@cairo-compile $(PROGRAM) > $(PROGRAM).json
 	@echo "Compiling done"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ docker_compile_and_run: target/release/lambdaworks-stark
 	@rm $(PROGRAM).json
 
 compile_and_run: target/release/lambdaworks-stark
-	cargo build --release
 	@echo "Compiling program with cairo-compile"
 	@cairo-compile $(PROGRAM) > $(PROGRAM).json
 	@echo "Compiling done"

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,17 @@ docker_build_cairo_compiler:
 	
 docker_compile_cairo:
 	docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(OUTPUT)
+
+docker_compile_and_run:
+	@echo "Compiling program with docker"
+	@docker run -v $(ROOT_DIR):/pwd cairo cairo-compile /pwd/$(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done"
+	@cargo run --quiet --release $(PROGRAM).json 
+	@rm $(PROGRAM).json
+
+compile_and_run:
+	@echo "Compiling program with cairo-compile"
+	@cairo-compile $(PROGRAM) > $(PROGRAM).json
+	@echo "Compiling done"
+	@cargo run --quiet --release $(PROGRAM).json 
+	@rm $(PROGRAM).json

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ clippy:
 
 build_metal:
 	cargo b --features metal --release
+
+run:
+	cargo run --release $(PATH)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can generate a proof for a compiled program with Cairo 0.11 and verify using
 
 For example, if you have a `program.json` in the project folder, you can use:
 
-`make run PATH=program.json`
+`make run PROGRAM_PATH=program.json`
 
 or
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ To be added:
 - Range check and Pedersen built-ins
 - Different layouts
 
+## Requirements
+
+- Cargo 1.69
+  
 ## How to try it
+## Using Docker compiler
+
+Build the compiler image with:
+
+`make docker_build_cairo_compiler`
+
+Then use:
+
+`make docker_compile_and_run PROGRAM=program_name.cairo`
+
+## Using cairo-compile
+
+`make compile_and_run PROGRAM=program_name.cairo`
 
 You can generate a proof for a compiled program with Cairo 0.11 and verify using `make run` or `cairo run`
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ For example, if you have a `program.json` in the project folder, you can use:
 or
 
 `cargo run --release program.json`
+## Compiling Cairo Programs to prove
+
+You can compile a program using `cairo-compile`, which requires `python3.9` and `cairo-lang`
+
+As an alternative, you can use the `Dockerfile` provided. 
+
+Build it with:
+
+`make docker_build_cairo_compiler`
+
+and compile programs with:
+
+`make docker_compile_cairo PROGRAM=program.cairo OUTPUT=program.json`

--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ To be added:
 - Optimizing verifier operations
 - Range check and Pedersen built-ins
 - Different layouts
+
+## How to try it
+
+You can generate a proof for a compiled program with Cairo 0.11 and verify using `make run` or `cairo run`
+
+For example, if you have a `program.json` in the project folder, you can use:
+
+`make run PATH=program.json`
+
+or
+
+`cargo run --release program.json`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To be added:
 
 ## Requirements
 
-- Cargo 1.69
+- Cargo 1.69+
   
 ## How to try it
 ## Using Docker compiler

--- a/cairo_compile.Dockerfile
+++ b/cairo_compile.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends g++ libgmp3-dev && \
+  pip install ecdsa==0.18.0 \
+  bitarray==2.7.3 \
+  fastecdsa==2.2.3 \
+  sympy==1.11.1 \
+  typeguard==2.13.3 \
+  cairo-lang==0.11.0
+
+CMD ["cairo-compile"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::time::{Instant};
+use std::time::Instant;
 
 use lambdaworks_stark::{cairo_run::run::generate_prover_args, prover::prove, verifier::verify};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     println!("Proof generated");
 
     println!("Verifying ...");
-    if verify(&proof, &cairo_air, &pub_inputs){
+    if verify(&proof, &cairo_air, &pub_inputs) {
         println!("Verification succeded");
     } else {
         println!("Verification failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::time::{Instant};
 
 use lambdaworks_stark::{cairo_run::run::generate_prover_args, prover::prove, verifier::verify};
 
@@ -8,9 +9,13 @@ fn main() {
     let file_path = &args[1];
     let (main_trace, cairo_air, mut pub_inputs) = generate_prover_args(file_path);
 
+    let timer = Instant::now();
     println!("Making proof ...");
     let proof = prove(&main_trace, &cairo_air, &mut pub_inputs).unwrap();
     println!("Proof generated");
+    println!("Time spent creating proof: {:?} ", timer.elapsed());
+
+    let timer = Instant::now();
 
     println!("Verifying ...");
     if verify(&proof, &cairo_air, &pub_inputs) {
@@ -18,4 +23,5 @@ fn main() {
     } else {
         println!("Verification failed");
     }
+    println!("Time spent verifying: {:?} ", timer.elapsed());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,21 @@
+use std::env;
+
+use lambdaworks_stark::{cairo_run::run::generate_prover_args, prover::prove, verifier::verify};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let file_path = &args[1];
+    let (main_trace, cairo_air, mut pub_inputs) = generate_prover_args(file_path);
+
+    println!("Making proof ...");
+    let proof = prove(&main_trace, &cairo_air, &mut pub_inputs).unwrap();
+    println!("Proof generated");
+
+    println!("Verifying ...");
+    if verify(&proof, &cairo_air, &pub_inputs){
+        println!("Verification succeded");
+    } else {
+        println!("Verification failed");
+    }
+}


### PR DESCRIPTION
- Add basic cairo run for making and verifying proofs
- Added a call to either cairo-compile or the cairo compiler Dockerfile to let the prove and verify run with a call of one line