### PR TITLE
bug: fix root order bug

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -354,7 +354,7 @@ where
 
     // FRI commit and query phases
     let (fri_last_value, fri_layers) = fri_commit_phase(
-        domain.root_order as usize,
+        domain.lde_root_order as usize,
         deep_composition_poly,
         transcript,
         &coset_offset,


### PR DESCRIPTION
When calculating FRI layers, the `lde_root_order` must be passed. We were passing the regular `root_order`, and these was hidden because our tests had trace lengths that were not very long.