### PR TITLE
bug: fix transition degrees

### DIFF
--- a/src/air/cairo_air/air.rs
+++ b/src/air/cairo_air/air.rs
@@ -216,6 +216,17 @@ impl CairoAIR {
             num_transition_constraints: 49,
         };
 
+        // The number of the transition constraints and the lengths of transition degrees
+        // and transition exemptions should be the same always.
+        debug_assert_eq!(
+            context.transition_degrees.len(),
+            context.num_transition_constraints
+        );
+        debug_assert_eq!(
+            context.transition_exemptions.len(),
+            context.num_transition_constraints
+        );
+
         Self {
             context,
             number_steps,

--- a/src/air/cairo_air/air.rs
+++ b/src/air/cairo_air/air.rs
@@ -197,7 +197,8 @@ impl CairoAIR {
                 2, 2, 2, 2, // Increasing memory auxiliary constraints.
                 2, 2, 2, 2, // Consistent memory auxiliary constraints.
                 2, 2, 2, 2, // Permutation auxiliary constraints.
-                2, 2, 2, // Permutation auxiliary constraints.
+                2, 2, 2, // range-check increasing constraints.
+                2, 2, 2, // range-check permutation argument constraints.
             ],
             transition_exemptions: vec![
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // flags (16)


### PR DESCRIPTION
There were some transitions constraints (continuous range-check values) that didn't had their degrees set in the Cairo AIR. This is something that does not affect in a lot of cases, but when developing builtin features and adding new constraints broke some things.