### PR TITLE
Lto thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ opt-level = 3
 codegen-units = 1
 
 [profile.test]
-lto = true
+lto = "thin"
 opt-level = 3
 debug = 2


### PR DESCRIPTION
Building tests take too much memory with LTO full and is too slow