### PR TITLE
generate_prover_args function receives the content of the program file

### DIFF
--- a/benches/criterion_starks.rs
+++ b/benches/criterion_starks.rs
@@ -33,8 +33,9 @@ fn cairo0_program_path(program_name: &str) -> String {
 }
 
 fn run_cairo_bench(group: &mut BenchmarkGroup<'_, WallTime>, benchname: &str, program_path: &str) {
+    let program_content = std::fs::read(program_path).unwrap();
     let (main_trace, cairo_air, mut pub_inputs) =
-        generate_prover_args(program_path, &CairoVersion::V0, &None, 1).unwrap();
+        generate_prover_args(&program_content, &CairoVersion::V0, &None, 1).unwrap();
 
     group.bench_function(benchname, |bench| {
         bench.iter(|| black_box(prove(&main_trace, &cairo_air, &mut pub_inputs).unwrap()));
@@ -62,8 +63,9 @@ fn run_verifier_bench(
     benchname: &str,
     program_path: &str,
 ) {
+    let program_content = std::fs::read(program_path).unwrap();
     let (main_trace, cairo_air, mut pub_inputs) =
-        generate_prover_args(program_path, &CairoVersion::V0, &None, 1).unwrap();
+        generate_prover_args(&program_content, &CairoVersion::V0, &None, 1).unwrap();
     let proof = prove(&main_trace, &cairo_air, &mut pub_inputs).unwrap();
 
     group.bench_function(benchname, |bench| {

--- a/src/cairo/air.rs
+++ b/src/cairo/air.rs
@@ -948,13 +948,9 @@ mod test {
 
     #[test]
     fn check_simple_cairo_trace_evaluates_to_zero() {
-        let (main_trace, cairo_air, public_input) = generate_prover_args(
-            &cairo0_program_path("simple_program.json"),
-            &CairoVersion::V0,
-            &None,
-            1,
-        )
-        .unwrap();
+        let program_content = std::fs::read(cairo0_program_path("simple_program.json")).unwrap();
+        let (main_trace, cairo_air, public_input) =
+            generate_prover_args(&program_content, &CairoVersion::V0, &None, 1).unwrap();
         let mut trace_polys = main_trace.compute_trace_polys();
         let mut transcript = DefaultTranscript::new();
         let rap_challenges = cairo_air.build_rap_challenges(&mut transcript);

--- a/src/cairo/execution_trace.rs
+++ b/src/cairo/execution_trace.rs
@@ -679,10 +679,11 @@ mod test {
         ```
         */
 
+        let program_content = std::fs::read(cairo0_program_path("simple_program.json")).unwrap();
         let (register_states, memory, program_size, _rangecheck_base_end) = run_program(
             None,
             CairoLayout::AllCairo,
-            &cairo0_program_path("simple_program.json"),
+            &program_content,
             &CairoVersion::V0,
         )
         .unwrap();
@@ -795,10 +796,11 @@ mod test {
         ```
         */
 
+        let program_content = std::fs::read(cairo0_program_path("call_func.json")).unwrap();
         let (register_states, memory, program_size, _rangecheck_base_end) = run_program(
             None,
             CairoLayout::AllCairo,
-            &cairo0_program_path("call_func.json"),
+            &program_content,
             &CairoVersion::V0,
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,13 @@ fn main() {
         CairoVersion::V0
     };
 
+    let Ok(program_content) = std::fs::read(file_path) else {
+        println!("ERROR opening {file_path} file");
+        return;
+    };
+
     let Ok((main_trace, cairo_air, mut pub_inputs)) =
-        generate_prover_args(file_path, &cairo_version, &None, grinding_factor) else {
+        generate_prover_args(&program_content, &cairo_version, &None, grinding_factor) else {
             println!("Error generating prover args");
             return;
         };


### PR DESCRIPTION
`generate_prover_args` function receives the content of the program filee instead of the path to the file.
This is because in some scenarios the program file is not saved to disk, but is passed directly to the prover.