### PR TITLE
Add trace length to proof

### DIFF
--- a/src/cairo/runner/run.rs
+++ b/src/cairo/runner/run.rs
@@ -272,7 +272,7 @@ pub fn generate_prover_args(
     let cairo_air = CairoAIR::new(
         proof_options,
         main_trace.n_rows(),
-        register_states.steps(),
+        pub_inputs.clone(),
         has_range_check_builtin,
     );
 

--- a/src/starks/constraints/evaluator.rs
+++ b/src/starks/constraints/evaluator.rs
@@ -119,7 +119,7 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
         let mut transition_evaluations = Vec::new();
 
         let transition_exemptions = self.air.transition_exemptions();
-        let trace_length = self.air.context().trace_length;
+        let trace_length = self.air.trace_length();
         let composition_poly_degree_bound = self.air.composition_poly_degree_bound();
         let boundary_term_degree_adjustment = composition_poly_degree_bound - trace_length;
 

--- a/src/starks/context.rs
+++ b/src/starks/context.rs
@@ -3,7 +3,6 @@ use super::proof::options::ProofOptions;
 #[derive(Clone, Debug)]
 pub struct AirContext {
     pub options: ProofOptions,
-    pub trace_length: usize,
     pub trace_columns: usize,
     pub transition_degrees: Vec<usize>,
 

--- a/src/starks/domain.rs
+++ b/src/starks/domain.rs
@@ -24,8 +24,8 @@ impl<F: IsFFTField> Domain<F> {
         // Initial definitions
         let blowup_factor = air.options().blowup_factor as usize;
         let coset_offset = FieldElement::<F>::from(air.options().coset_offset);
-        let interpolation_domain_size = air.context().trace_length;
-        let root_order = air.context().trace_length.trailing_zeros();
+        let interpolation_domain_size = air.trace_length();
+        let root_order = air.trace_length().trailing_zeros();
         // * Generate Coset
         let trace_primitive_root = F::get_primitive_root_of_unity(root_order as u64).unwrap();
         let trace_roots_of_unity = get_powers_of_primitive_root_coset(
@@ -35,10 +35,10 @@ impl<F: IsFFTField> Domain<F> {
         )
         .unwrap();
 
-        let lde_root_order = (air.context().trace_length * blowup_factor).trailing_zeros();
+        let lde_root_order = (air.trace_length() * blowup_factor).trailing_zeros();
         let lde_roots_of_unity_coset = get_powers_of_primitive_root_coset(
             lde_root_order as u64,
-            air.context().trace_length * blowup_factor,
+            air.trace_length() * blowup_factor,
             &coset_offset,
         )
         .unwrap();

--- a/src/starks/example/dummy_air.rs
+++ b/src/starks/example/dummy_air.rs
@@ -19,7 +19,7 @@ pub struct DummyAIR {
 }
 
 impl DummyAIR {
-    fn new(context: AirContext, trace_length: usize) -> Self {
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
         Self {
             context,
             trace_length,

--- a/src/starks/example/dummy_air.rs
+++ b/src/starks/example/dummy_air.rs
@@ -15,11 +15,15 @@ use crate::starks::{
 #[derive(Clone)]
 pub struct DummyAIR {
     context: AirContext,
+    trace_length: usize,
 }
 
-impl From<AirContext> for DummyAIR {
-    fn from(context: AirContext) -> Self {
-        Self { context }
+impl DummyAIR {
+    fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -74,7 +78,11 @@ impl AIR for DummyAIR {
     }
 
     fn composition_poly_degree_bound(&self) -> usize {
-        self.context().trace_length
+        self.trace_length
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }
 

--- a/src/starks/example/fibonacci_2_columns.rs
+++ b/src/starks/example/fibonacci_2_columns.rs
@@ -15,11 +15,15 @@ use crate::starks::{
 #[derive(Clone, Debug)]
 pub struct Fibonacci2ColsAIR {
     context: AirContext,
+    trace_length: usize,
 }
 
-impl From<AirContext> for Fibonacci2ColsAIR {
-    fn from(context: AirContext) -> Self {
-        Self { context }
+impl Fibonacci2ColsAIR {
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -76,7 +80,11 @@ impl AIR for Fibonacci2ColsAIR {
     }
 
     fn composition_poly_degree_bound(&self) -> usize {
-        self.context().trace_length
+        self.trace_length()
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }
 

--- a/src/starks/example/fibonacci_f17.rs
+++ b/src/starks/example/fibonacci_f17.rs
@@ -12,11 +12,15 @@ use crate::starks::{
 #[derive(Clone)]
 pub struct Fibonacci17AIR {
     context: AirContext,
+    trace_length: usize,
 }
 
-impl From<AirContext> for Fibonacci17AIR {
-    fn from(context: AirContext) -> Self {
-        Self { context }
+impl Fibonacci17AIR {
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -69,6 +73,10 @@ impl AIR for Fibonacci17AIR {
     }
 
     fn composition_poly_degree_bound(&self) -> usize {
-        self.context().trace_length
+        self.trace_length()
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }

--- a/src/starks/example/fibonacci_rap.rs
+++ b/src/starks/example/fibonacci_rap.rs
@@ -21,11 +21,15 @@ use crate::starks::{
 #[derive(Clone)]
 pub struct FibonacciRAP {
     context: AirContext,
+    trace_length: usize,
 }
 
 impl FibonacciRAP {
-    pub fn new(context: AirContext) -> Self {
-        Self { context }
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -115,7 +119,11 @@ impl AIR for FibonacciRAP {
     }
 
     fn composition_poly_degree_bound(&self) -> usize {
-        self.context().trace_length
+        self.trace_length()
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }
 

--- a/src/starks/example/quadratic_air.rs
+++ b/src/starks/example/quadratic_air.rs
@@ -15,11 +15,15 @@ use crate::starks::{
 #[derive(Clone)]
 pub struct QuadraticAIR {
     context: AirContext,
+    trace_length: usize,
 }
 
-impl From<AirContext> for QuadraticAIR {
-    fn from(context: AirContext) -> Self {
-        Self { context }
+impl QuadraticAIR {
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -69,7 +73,11 @@ impl AIR for QuadraticAIR {
     }
 
     fn composition_poly_degree_bound(&self) -> usize {
-        2 * self.context().trace_length
+        2 * self.trace_length()
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }
 

--- a/src/starks/example/simple_fibonacci.rs
+++ b/src/starks/example/simple_fibonacci.rs
@@ -15,11 +15,15 @@ use crate::starks::{
 #[derive(Clone)]
 pub struct FibonacciAIR {
     context: AirContext,
+    trace_length: usize,
 }
 
-impl From<AirContext> for FibonacciAIR {
-    fn from(context: AirContext) -> Self {
-        Self { context }
+impl FibonacciAIR {
+    pub fn new(context: AirContext, trace_length: usize) -> Self {
+        Self {
+            context,
+            trace_length,
+        }
     }
 }
 
@@ -29,7 +33,7 @@ impl AIR for FibonacciAIR {
     type PublicInput = ();
 
     fn composition_poly_degree_bound(&self) -> usize {
-        self.context().trace_length
+        self.trace_length()
     }
 
     fn build_auxiliary_trace(
@@ -71,6 +75,10 @@ impl AIR for FibonacciAIR {
 
     fn context(&self) -> &AirContext {
         &self.context
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
     }
 }
 

--- a/src/starks/proof/stark.rs
+++ b/src/starks/proof/stark.rs
@@ -44,6 +44,8 @@ pub struct StarkProof<F: IsFFTField> {
     pub deep_poly_openings: Vec<DeepPolynomialOpenings<F>>,
     // nonce obtained from grinding
     pub nonce: u64,
+    // Length of the execution trace
+    pub trace_length: usize,
 }
 
 impl<F> Serializable for DeepPolynomialOpenings<F>

--- a/src/starks/prover.rs
+++ b/src/starks/prover.rs
@@ -764,7 +764,6 @@ mod tests {
                 coset_offset,
                 grinding_factor,
             },
-            // trace_length,
             trace_columns: trace.n_cols,
             transition_degrees: vec![1],
             transition_exemptions: vec![2],

--- a/src/starks/prover.rs
+++ b/src/starks/prover.rs
@@ -772,7 +772,7 @@ mod tests {
             num_transition_constraints: 1,
         };
 
-        let domain = Domain::new(&simple_fibonacci::FibonacciAIR::from(context));
+        let domain = Domain::new(&simple_fibonacci::FibonacciAIR::new(context, trace_length));
         assert_eq!(domain.blowup_factor, 2);
         assert_eq!(domain.interpolation_domain_size, trace_length);
         assert_eq!(domain.root_order, trace_length.trailing_zeros());

--- a/src/starks/prover.rs
+++ b/src/starks/prover.rs
@@ -728,6 +728,8 @@ where
         deep_poly_openings: round_4_result.deep_poly_openings,
         // nonce obtained from grinding
         nonce: round_4_result.nonce,
+
+        trace_length: air.trace_length(),
     })
 }
 
@@ -762,7 +764,7 @@ mod tests {
                 coset_offset,
                 grinding_factor,
             },
-            trace_length,
+            // trace_length,
             trace_columns: trace.n_cols,
             transition_degrees: vec![1],
             transition_exemptions: vec![2],

--- a/src/starks/traits.rs
+++ b/src/starks/traits.rs
@@ -42,11 +42,11 @@ pub trait AIR: Clone {
     ) -> BoundaryConstraints<Self::Field>;
 
     fn transition_exemptions(&self) -> Vec<Polynomial<FieldElement<Self::Field>>> {
-        let trace_length = self.context().trace_length;
+        let trace_length = self.trace_length();
         let roots_of_unity_order = trace_length.trailing_zeros();
         let roots_of_unity = get_powers_of_primitive_root_coset(
             roots_of_unity_order as u64,
-            self.context().trace_length,
+            self.trace_length(),
             &FieldElement::<Self::Field>::one(),
         )
         .unwrap();
@@ -72,6 +72,8 @@ pub trait AIR: Clone {
             .collect()
     }
     fn context(&self) -> &AirContext;
+
+    fn trace_length(&self) -> usize;
 
     fn options(&self) -> &ProofOptions {
         &self.context().options

--- a/src/starks/verifier.rs
+++ b/src/starks/verifier.rs
@@ -213,7 +213,7 @@ fn step_2_verify_claimed_composition_polynomial<F: IsFFTField, A: AIR<Field = F>
 
     let n_trace_cols = air.context().trace_columns;
     // special cases.
-    let trace_length = air.context().trace_length;
+    let trace_length = air.trace_length();
     let composition_poly_degree_bound = air.composition_poly_degree_bound();
     let boundary_term_degree_adjustment = composition_poly_degree_bound - trace_length;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -43,7 +43,6 @@ fn test_prove_fib() {
             coset_offset: 3,
             grinding_factor: 1,
         },
-        trace_length,
         trace_columns: 1,
         transition_degrees: vec![1],
         transition_exemptions: vec![2],
@@ -51,7 +50,7 @@ fn test_prove_fib() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = simple_fibonacci::FibonacciAIR::from(context);
+    let fibonacci_air = simple_fibonacci::FibonacciAIR::new(context, trace_length);
 
     let result = prove(&trace, &fibonacci_air, &mut ()).unwrap();
     assert!(verify(&result, &fibonacci_air, &()));
@@ -69,7 +68,6 @@ fn test_prove_fib17() {
             coset_offset: 3,
             grinding_factor: 10,
         },
-        trace_length,
         trace_columns: 1,
         transition_degrees: vec![1],
         transition_exemptions: vec![2],
@@ -77,7 +75,7 @@ fn test_prove_fib17() {
         num_transition_constraints: 1,
     };
 
-    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::from(context);
+    let fibonacci_air = fibonacci_f17::Fibonacci17AIR::new(context, trace_length);
 
     let result = prove(&trace, &fibonacci_air, &mut ()).unwrap();
     assert!(verify(&result, &fibonacci_air, &()));
@@ -95,7 +93,6 @@ fn test_prove_fib_2_cols() {
             coset_offset: 3,
             grinding_factor: 1,
         },
-        trace_length,
         transition_degrees: vec![1, 1],
         transition_exemptions: vec![1, 1],
         transition_offsets: vec![0, 1],
@@ -103,7 +100,7 @@ fn test_prove_fib_2_cols() {
         trace_columns: 2,
     };
 
-    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::from(context);
+    let fibonacci_air = fibonacci_2_columns::Fibonacci2ColsAIR::new(context, trace_length);
 
     let result = prove(&trace, &fibonacci_air, &mut ()).unwrap();
     assert!(verify(&result, &fibonacci_air, &()));
@@ -121,7 +118,6 @@ fn test_prove_quadratic() {
             coset_offset: 3,
             grinding_factor: 1,
         },
-        trace_length,
         trace_columns: 1,
         transition_degrees: vec![2],
         transition_exemptions: vec![1],
@@ -129,7 +125,7 @@ fn test_prove_quadratic() {
         num_transition_constraints: 1,
     };
 
-    let quadratic_air = quadratic_air::QuadraticAIR::from(context);
+    let quadratic_air = quadratic_air::QuadraticAIR::new(context, trace_length);
 
     let result = prove(&trace, &quadratic_air, &mut ()).unwrap();
     assert!(verify(&result, &quadratic_air, &()));
@@ -213,14 +209,13 @@ fn test_prove_rap_fib() {
             grinding_factor: 1,
         },
         trace_columns: 3,
-        trace_length: trace_cols[0].len(),
         transition_degrees: vec![1, 2],
         transition_offsets: vec![0, 1, 2],
         transition_exemptions: vec![exemptions, 1],
         num_transition_constraints: 2,
     };
 
-    let fibonacci_rap = FibonacciRAP::new(context);
+    let fibonacci_rap = FibonacciRAP::new(context, trace_cols[0].len());
 
     let result = prove(&trace, &fibonacci_rap, &mut ()).unwrap();
     assert!(verify(&result, &fibonacci_rap, &()));
@@ -238,7 +233,6 @@ fn test_prove_dummy() {
             coset_offset: 3,
             grinding_factor: 1,
         },
-        trace_length,
         trace_columns: 2,
         transition_degrees: vec![2, 1],
         transition_exemptions: vec![0, 2],
@@ -246,7 +240,7 @@ fn test_prove_dummy() {
         num_transition_constraints: 2,
     };
 
-    let dummy_air = dummy_air::DummyAIR::from(context);
+    let dummy_air = dummy_air::DummyAIR::new(context, trace_length);
 
     let result = prove(&trace, &dummy_air, &mut ()).unwrap();
     assert!(verify(&result, &dummy_air, &()));
@@ -346,7 +340,7 @@ fn test_verifier_rejects_proof_with_overflowing_range_check_value() {
     let cairo_air = CairoAIR::new(
         proof_options,
         malicious_trace.n_rows(),
-        register_states.steps(),
+        pub_inputs.clone(),
         true,
     );
 


### PR DESCRIPTION
In order to progressively decouple prover from verifier, the trace length is passed in the proof.