### PR TITLE
removed unnecessary transition adjustment evals

### DIFF
--- a/src/starks/constraints/evaluator.rs
+++ b/src/starks/constraints/evaluator.rs
@@ -136,11 +136,9 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
             })
             .collect();
 
-       
         let context = self.air.context();
-        let max_transition_degree= context
-        .transition_degrees.iter().max().unwrap().clone();
-        
+        let max_transition_degree = *context.transition_degrees.iter().max().unwrap();
+
         let degree_adjustments: Vec<Vec<FieldElement<F>>> = (1..=max_transition_degree)
             .map(|transition_degree| {
                 domain
@@ -206,7 +204,9 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
             let degree_adjustments: Vec<_> = context
                 .transition_degrees
                 .iter()
-                .map(|transition_adjustments| degree_adjustments[transition_adjustments.clone() -1][i].clone())
+                .map(|&transition_adjustments| {
+                    degree_adjustments[transition_adjustments - 1][i].clone()
+                })
                 .collect();
 
             let mut evaluations_sum = Self::compute_constraint_composition_poly_evaluations_sum(

--- a/src/starks/constraints/evaluator.rs
+++ b/src/starks/constraints/evaluator.rs
@@ -136,10 +136,28 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
             })
             .collect();
 
+       
         let context = self.air.context();
+        let max_transition_degree= context
+        .transition_degrees.iter().max().unwrap().clone();
+        /*
         let degree_adjustments: Vec<Vec<FieldElement<F>>> = context
             .transition_degrees()
             .iter()
+            .map(|transition_degree| {
+                domain
+                    .lde_roots_of_unity_coset
+                    .iter()
+                    .map(|d| {
+                        let degree_adjustment = composition_poly_degree_bound
+                            - (trace_length * (transition_degree - 1));
+                        d.pow(degree_adjustment)
+                    })
+                    .collect()
+            })
+            .collect();
+        */
+        let degree_adjustments: Vec<Vec<FieldElement<F>>> = (1..=max_transition_degree)
             .map(|transition_degree| {
                 domain
                     .lde_roots_of_unity_coset
@@ -201,9 +219,10 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
                 .iter()
                 .map(|zerofier_evals| zerofier_evals[i].clone())
                 .collect();
-            let degree_adjustments: Vec<_> = degree_adjustments
+            let degree_adjustments: Vec<_> = context
+                .transition_degrees
                 .iter()
-                .map(|transition_adjustments| transition_adjustments[i].clone())
+                .map(|transition_adjustments| degree_adjustments[transition_adjustments.clone() -1][i].clone())
                 .collect();
 
             let mut evaluations_sum = Self::compute_constraint_composition_poly_evaluations_sum(

--- a/src/starks/constraints/evaluator.rs
+++ b/src/starks/constraints/evaluator.rs
@@ -140,23 +140,7 @@ impl<'poly, F: IsFFTField, A: AIR + AIR<Field = F>> ConstraintEvaluator<'poly, F
         let context = self.air.context();
         let max_transition_degree= context
         .transition_degrees.iter().max().unwrap().clone();
-        /*
-        let degree_adjustments: Vec<Vec<FieldElement<F>>> = context
-            .transition_degrees()
-            .iter()
-            .map(|transition_degree| {
-                domain
-                    .lde_roots_of_unity_coset
-                    .iter()
-                    .map(|d| {
-                        let degree_adjustment = composition_poly_degree_bound
-                            - (trace_length * (transition_degree - 1));
-                        d.pow(degree_adjustment)
-                    })
-                    .collect()
-            })
-            .collect();
-        */
+        
         let degree_adjustments: Vec<Vec<FieldElement<F>>> = (1..=max_transition_degree)
             .map(|transition_degree| {
                 domain


### PR DESCRIPTION
Currently, the code calculates the degree adjustment for every transition degree. However, there are only 3 options in the CAIRO AIR: 1,2,3. Therefore, going for all the 49 values of transition constraints is unnecessary. Perf is increased by 12,5%