### PR TITLE
Moved repeated divisions

### DIFF
--- a/src/starks/verifier.rs
+++ b/src/starks/verifier.rs
@@ -503,10 +503,16 @@ fn reconstruct_deep_composition_poly_evaluation<F: IsFFTField, A: AIR<Field = F>
     i: usize,
 ) -> FieldElement<F> {
     let primitive_root = &F::get_primitive_root_of_unity(domain.root_order as u64).unwrap();
+    // It's better to take this out of the function and perform batch inversion
     let upsilon_0 = &domain.lde_roots_of_unity_coset[iota_n];
 
     let mut trace_terms = FieldElement::zero();
-
+    let z_squared = &(&challenges.z * &challenges.z);
+    let den = (upsilon_0 - z_squared).inv();
+    let mut divisors = (0..proof.trace_ood_frame_evaluations.num_rows())
+                .map(|row_idx| (upsilon_0 - &challenges.z * primitive_root.pow(row_idx as u64)))
+                .collect::<Vec<FieldElement<F>>>();
+    FieldElement::inplace_batch_inverse(&mut divisors);
     for (col_idx, coeff_row) in
         (0..proof.trace_ood_frame_evaluations.num_columns()).zip(&challenges.trace_term_coeffs)
     {
@@ -514,20 +520,20 @@ fn reconstruct_deep_composition_poly_evaluation<F: IsFFTField, A: AIR<Field = F>
             let poly_evaluation = (proof.deep_poly_openings[i].lde_trace_evaluations[col_idx]
                 .clone()
                 - proof.trace_ood_frame_evaluations.get_row(row_idx)[col_idx].clone())
-                / (upsilon_0 - &challenges.z * primitive_root.pow(row_idx as u64));
+                * &divisors[row_idx];
 
             trace_terms += &poly_evaluation * coeff;
         }
     }
 
-    let z_squared = &(&challenges.z * &challenges.z);
+    
     let h_1_upsilon_0 = &proof.deep_poly_openings[i].lde_composition_poly_even_evaluation;
     let h_1_zsquared = &proof.composition_poly_even_ood_evaluation;
     let h_2_upsilon_0 = &proof.deep_poly_openings[i].lde_composition_poly_odd_evaluation;
     let h_2_zsquared = &proof.composition_poly_odd_ood_evaluation;
-
-    let h_1_term = (h_1_upsilon_0 - h_1_zsquared) / (upsilon_0 - z_squared);
-    let h_2_term = (h_2_upsilon_0 - h_2_zsquared) / (upsilon_0 - z_squared);
+    
+    let h_1_term = (h_1_upsilon_0 - h_1_zsquared) * &den ;
+    let h_2_term = (h_2_upsilon_0 - h_2_zsquared) * &den;
 
     trace_terms + h_1_term * &challenges.gamma_even + h_2_term * &challenges.gamma_odd
 }


### PR DESCRIPTION
Reduced time spent in computing composition polynomial. There were nested divisions in code, moved them outside and performed batch inversion. For Fib10, verifier time was reduced by 55%, for Fib100, 20% (this is due to the fact that for larger programs the burden is somewhere else).