### PR TITLE
Precompute twiddle factors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a21d2c5" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a21d2c5" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", branch = "fft_with_twiddles_param" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", branch = "fft_with_twiddles_param" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/src/cairo/decode/instruction_flags.rs
+++ b/src/cairo/decode/instruction_flags.rs
@@ -1,5 +1,4 @@
 use crate::{cairo::errors::InstructionDecodingError, FE};
-use lambdaworks_math::traits::ByteConversion;
 
 // Constants for instructions decoding
 const DST_REG_MASK: u64 = 0x0001;

--- a/src/starks/constraints/boundary.rs
+++ b/src/starks/constraints/boundary.rs
@@ -133,8 +133,8 @@ mod test {
         //   * a0 = 1
         //   * a1 = 1
         //   * a7 = 32
-        let a0 = BoundaryConstraint::new_simple(0, one.clone());
-        let a1 = BoundaryConstraint::new_simple(1, one.clone());
+        let a0 = BoundaryConstraint::new_simple(0, one);
+        let a1 = BoundaryConstraint::new_simple(1, one);
         let result = BoundaryConstraint::new_simple(7, FieldElement::<PrimeField>::from(32));
 
         let constraints = BoundaryConstraints::from_constraints(vec![a0, a1, result]);
@@ -142,9 +142,9 @@ mod test {
         let primitive_root = PrimeField::get_primitive_root_of_unity(3).unwrap();
 
         // P_0(x) = (x - 1)
-        let a0_zerofier = Polynomial::new(&[-one.clone(), one.clone()]);
+        let a0_zerofier = Polynomial::new(&[-one, one]);
         // P_1(x) = (x - w^1)
-        let a1_zerofier = Polynomial::new(&[-primitive_root.pow(1u32), one.clone()]);
+        let a1_zerofier = Polynomial::new(&[-primitive_root.pow(1u32), one]);
         // P_res(x) = (x - w^7)
         let res_zerofier = Polynomial::new(&[-primitive_root.pow(7u32), one]);
 

--- a/src/starks/constraints/evaluator.rs
+++ b/src/starks/constraints/evaluator.rs
@@ -8,7 +8,6 @@ use lambdaworks_math::{
 #[cfg(debug_assertions)]
 use crate::starks::debug::check_boundary_polys_divisibility;
 use crate::starks::frame::Frame;
-use crate::starks::prover::evaluate_polynomial_on_lde_domain;
 use crate::starks::trace::TraceTable;
 use crate::starks::traits::AIR;
 use crate::starks::{domain::Domain, prover::evaluate_polynomial_on_lde_domain_with_twiddles};

--- a/src/starks/example/dummy_air.rs
+++ b/src/starks/example/dummy_air.rs
@@ -51,9 +51,9 @@ impl AIR for DummyAIR {
         let second_row = frame.get_row(1);
         let third_row = frame.get_row(2);
 
-        let f_constraint = &first_row[0] * (&first_row[0] - FieldElement::one());
+        let f_constraint = first_row[0] * (first_row[0] - FieldElement::one());
 
-        let fib_constraint = &third_row[1] - &second_row[1] - &first_row[1];
+        let fib_constraint = third_row[1] - second_row[1] - first_row[1];
 
         vec![f_constraint, fib_constraint]
     }

--- a/src/starks/example/fibonacci_2_columns.rs
+++ b/src/starks/example/fibonacci_2_columns.rs
@@ -54,8 +54,8 @@ impl AIR for Fibonacci2ColsAIR {
         // constraints of Fibonacci sequence (2 terms per step):
         // s_{0, i+1} = s_{0, i} + s_{1, i}
         // s_{1, i+1} = s_{1, i} + s_{0, i+1}
-        let first_transition = &second_row[0] - &first_row[0] - &first_row[1];
-        let second_transition = &second_row[1] - &first_row[1] - &second_row[0];
+        let first_transition = second_row[0] - first_row[0] - first_row[1];
+        let second_transition = second_row[1] - first_row[1] - second_row[0];
 
         vec![first_transition, second_transition]
     }

--- a/src/starks/example/fibonacci_rap.rs
+++ b/src/starks/example/fibonacci_rap.rs
@@ -56,8 +56,8 @@ impl AIR for FibonacciRAP {
                 aux_col.push(FieldElement::<Self::Field>::one());
             } else {
                 let z_i = &aux_col[i - 1];
-                let n_p_term = not_perm[i - 1].clone() + gamma;
-                let p_term = &perm[i - 1] + gamma;
+                let n_p_term = not_perm[i - 1] + gamma;
+                let p_term = perm[i - 1] + gamma;
 
                 aux_col.push(z_i * n_p_term.div(p_term));
             }
@@ -83,8 +83,7 @@ impl AIR for FibonacciRAP {
         let second_row = frame.get_row(1);
         let third_row = frame.get_row(2);
 
-        let mut constraints =
-            vec![third_row[0].clone() - second_row[0].clone() - first_row[0].clone()];
+        let mut constraints = vec![third_row[0] - second_row[0] - first_row[0]];
 
         // Auxiliary constraints
         let z_i = &frame.get_row(0)[2];

--- a/src/starks/example/quadratic_air.rs
+++ b/src/starks/example/quadratic_air.rs
@@ -51,7 +51,7 @@ impl AIR for QuadraticAIR {
         let first_row = frame.get_row(0);
         let second_row = frame.get_row(1);
 
-        vec![&second_row[0] - &first_row[0] * &first_row[0]]
+        vec![second_row[0] - first_row[0] * first_row[0]]
     }
 
     fn number_auxiliary_rap_columns(&self) -> usize {

--- a/src/starks/example/simple_fibonacci.rs
+++ b/src/starks/example/simple_fibonacci.rs
@@ -55,7 +55,7 @@ impl AIR for FibonacciAIR {
         let second_row = frame.get_row(1);
         let third_row = frame.get_row(2);
 
-        vec![third_row[0].clone() - second_row[0].clone() - first_row[0].clone()]
+        vec![third_row[0] - second_row[0] - first_row[0]]
     }
 
     fn boundary_constraints(

--- a/src/starks/prover.rs
+++ b/src/starks/prover.rs
@@ -847,7 +847,7 @@ mod tests {
             for (i, evaluation) in lde_evaluation.iter().enumerate() {
                 assert_eq!(
                     *evaluation,
-                    poly.evaluate(&(&coset_offset * primitive_root.pow(i)))
+                    poly.evaluate(&(coset_offset * primitive_root.pow(i)))
                 );
             }
         }
@@ -868,7 +868,7 @@ mod tests {
         )
         .unwrap();
         for (i, eval) in evaluations.iter().enumerate() {
-            assert_eq!(*eval, poly.evaluate(&(&offset * &primitive_root.pow(i))));
+            assert_eq!(*eval, poly.evaluate(&(offset * primitive_root.pow(i))));
         }
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -348,7 +348,7 @@ fn test_verifier_rejects_proof_with_overflowing_range_check_value() {
     assert!(!verify(&proof, &cairo_air, &pub_inputs));
 }
 
-#[test_log::test]
+#[test]
 fn test_verifier_rejects_proof_with_changed_output() {
     let program_content = std::fs::read(cairo0_program_path("output_program.json")).unwrap();
     let (main_trace, cairo_air, mut public_input) =


### PR DESCRIPTION
Resolves #107.
This PR adds twiddle factors precomputation. The twiddle factors affected are the ones that form a vector of length `domain_size`.
It also fixes linter issues related with the usage of the updated Lambdaworks crates.
It improves the performance of the prover by 4% for fibo 10 and 3% for fibo 100 and regresses the performance of the verifier by 2% for fibo 10 and 3% for fibo 100.