### PR TITLE
Bump lambdaworks a17b951

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.66"
 
 [dependencies]
 rand = "0.8.5"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a21d2c5" }
-lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a21d2c5" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a17b951" }
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a17b951" }
 thiserror = "1.0.38"
 log = "0.4.17"
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git" }

--- a/src/cairo/air.rs
+++ b/src/cairo/air.rs
@@ -782,10 +782,8 @@ impl AIR for CairoAIR {
         &self,
         rap_challenges: &Self::RAPChallenges,
     ) -> BoundaryConstraints<Self::Field> {
-        let initial_pc =
-            BoundaryConstraint::new(MEM_A_TRACE_OFFSET, 0, self.pub_inputs.pc_init);
-        let initial_ap =
-            BoundaryConstraint::new(MEM_P_TRACE_OFFSET, 0, self.pub_inputs.ap_init);
+        let initial_pc = BoundaryConstraint::new(MEM_A_TRACE_OFFSET, 0, self.pub_inputs.pc_init);
+        let initial_ap = BoundaryConstraint::new(MEM_P_TRACE_OFFSET, 0, self.pub_inputs.ap_init);
 
         let final_pc = BoundaryConstraint::new(
             MEM_A_TRACE_OFFSET,

--- a/src/cairo/decode/instruction_flags.rs
+++ b/src/cairo/decode/instruction_flags.rs
@@ -1,6 +1,4 @@
 use crate::{cairo::errors::InstructionDecodingError, FE};
-use lambdaworks_math::traits::ByteConversion;
-
 // Constants for instructions decoding
 const DST_REG_MASK: u64 = 0x0001;
 const DST_REG_OFF: u64 = 0;

--- a/src/cairo/execution_trace.rs
+++ b/src/cairo/execution_trace.rs
@@ -210,7 +210,7 @@ fn get_memory_holes(sorted_addrs: &[FE], codelen: usize) -> Vec<FE> {
 
             while hole_addr.representative() < addr.representative() {
                 if hole_addr.representative() > (codelen as u64).into() {
-                    memory_holes.push(hole_addr.clone());
+                    memory_holes.push(hole_addr);
                 }
                 hole_addr += FE::one();
             }
@@ -246,7 +246,7 @@ fn fill_memory_holes(trace: &mut TraceTable<Stark252PrimeField>, memory_holes: &
         // columns.
         addr_cols.iter().for_each(|a_col| {
             if let Some(hole) = memory_holes_iter.next() {
-                padding_row[*a_col] = hole.clone();
+                padding_row[*a_col] = *hole;
             }
         });
 
@@ -303,7 +303,7 @@ pub fn build_cairo_execution_trace(
     let instructions: Vec<FE> = raw_trace
         .rows
         .iter()
-        .map(|t| memory.get(&t.pc).unwrap().clone())
+        .map(|t| *memory.get(&t.pc).unwrap())
         .collect();
 
     // t0, t1 and mul derived values are constructed. For details refer to
@@ -311,7 +311,7 @@ pub fn build_cairo_execution_trace(
     let t0: Vec<FE> = trace_repr_flags
         .iter()
         .zip(&dsts)
-        .map(|(repr_flags, dst)| repr_flags[9].clone() * dst)
+        .map(|(repr_flags, dst)| repr_flags[9] * dst)
         .collect();
     let t1: Vec<FE> = t0.iter().zip(&res).map(|(t, r)| t * r).collect();
     let mul: Vec<FE> = op0s.iter().zip(&op1s).map(|(op0, op1)| op0 * op1).collect();
@@ -373,7 +373,7 @@ fn add_rc_builtin_columns(
     });
 
     let mut rc_values_dereferenced: Vec<FE> =
-        range_checked_values.iter().map(|&x| x.clone()).collect();
+        range_checked_values.iter().map(|&x| *x).collect();
     rc_values_dereferenced.resize(trace_cols[0].len(), FE::zero());
 
     trace_cols.push(rc_values_dereferenced);
@@ -417,7 +417,7 @@ fn compute_res(flags: &[CairoInstructionFlags], op0s: &[FE], op1s: &[FE], dsts: 
                             // values later on.
                             // See section 9.5 of the Cairo whitepaper, page 53.
                             if dst == &FE::zero() {
-                                dst.clone()
+                                *dst
                             } else {
                                 dst.inv()
                             }
@@ -428,7 +428,7 @@ fn compute_res(flags: &[CairoInstructionFlags], op0s: &[FE], op1s: &[FE], dsts: 
                     }
                 }
                 PcUpdate::Regular | PcUpdate::Jump | PcUpdate::JumpRel => match f.res_logic {
-                    ResLogic::Op1 => op1.clone(),
+                    ResLogic::Op1 => *op1,
                     ResLogic::Add => op0 + op1,
                     ResLogic::Mul => op0 * op1,
                     ResLogic::Unconstrained => {
@@ -464,11 +464,11 @@ fn compute_dst(
         .map(|((f, o), t)| match f.dst_reg {
             DstReg::AP => {
                 let addr = t.ap.checked_add_signed(o.off_dst.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
             DstReg::FP => {
                 let addr = t.fp.checked_add_signed(o.off_dst.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
         })
         .unzip()
@@ -498,11 +498,11 @@ fn compute_op0(
         .map(|((f, o), t)| match f.op0_reg {
             Op0Reg::AP => {
                 let addr = t.ap.checked_add_signed(o.off_op0.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
             Op0Reg::FP => {
                 let addr = t.fp.checked_add_signed(o.off_op0.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
         })
         .unzip()
@@ -547,22 +547,22 @@ fn compute_op1(
                 let addr = aux_get_last_nim_of_field_element(op0)
                     .checked_add_signed(offset.off_op1.into())
                     .unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
             Op1Src::Imm => {
                 let pc = trace_state.pc;
                 let addr = pc.checked_add_signed(offset.off_op1.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
             Op1Src::AP => {
                 let ap = trace_state.ap;
                 let addr = ap.checked_add_signed(offset.off_op1.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
             Op1Src::FP => {
                 let fp = trace_state.fp;
                 let addr = fp.checked_add_signed(offset.off_op1.into()).unwrap();
-                (FE::from(addr), memory.get(&addr).unwrap().clone())
+                (FE::from(addr), *memory.get(&addr).unwrap())
             }
         })
         .unzip()
@@ -587,7 +587,7 @@ fn update_values(
             op0s[i] = (register_states.rows[i].pc + instruction_size).into();
             dst[i] = register_states.rows[i].fp.into();
         } else if f.opcode == CairoOpcode::AssertEq {
-            res[i] = dst[i].clone();
+            res[i] = dst[i];
         }
     }
 }
@@ -601,7 +601,7 @@ fn rows_to_cols<const N: usize>(rows: &[[FE; N]]) -> Vec<Vec<FE>> {
     for col_idx in 0..n_cols {
         let mut col = Vec::new();
         for row in rows {
-            col.push(row[col_idx].clone());
+            col.push(row[col_idx]);
         }
         cols.push(col);
     }

--- a/src/cairo/execution_trace.rs
+++ b/src/cairo/execution_trace.rs
@@ -372,8 +372,7 @@ fn add_rc_builtin_columns(
         trace_cols.push(column.to_vec())
     });
 
-    let mut rc_values_dereferenced: Vec<FE> =
-        range_checked_values.iter().map(|&x| *x).collect();
+    let mut rc_values_dereferenced: Vec<FE> = range_checked_values.iter().map(|&x| *x).collect();
     rc_values_dereferenced.resize(trace_cols[0].len(), FE::zero());
 
     trace_cols.push(rc_values_dereferenced);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
-
 // Op ref suggest to not use references with FieldElements operations
 // This adds overhead of copying all the limbs, so clippy op_ref is disabled
-#![allow(
-    clippy::op_ref
-  )]
+#![allow(clippy::op_ref)]
 
 use lambdaworks_math::field::{
     element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+
+// Op ref suggest to not use references with FieldElements operations
+// This adds overhead of copying all the limbs, so clippy op_ref is disabled
+#![allow(
+    clippy::op_ref
+  )]
+
 use lambdaworks_math::field::{
     element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };

--- a/src/starks/constraints/boundary.rs
+++ b/src/starks/constraints/boundary.rs
@@ -142,8 +142,8 @@ mod test {
         //   * a0 = 1
         //   * a1 = 1
         //   * a7 = 32
-        let a0 = BoundaryConstraint::new_simple(0, one.clone());
-        let a1 = BoundaryConstraint::new_simple(1, one.clone());
+        let a0 = BoundaryConstraint::new_simple(0, one);
+        let a1 = BoundaryConstraint::new_simple(1, one);
         let result = BoundaryConstraint::new_simple(7, FieldElement::<PrimeField>::from(32));
 
         let constraints = BoundaryConstraints::from_constraints(vec![a0, a1, result]);
@@ -151,9 +151,9 @@ mod test {
         let primitive_root = PrimeField::get_primitive_root_of_unity(3).unwrap();
 
         // P_0(x) = (x - 1)
-        let a0_zerofier = Polynomial::new(&[-one.clone(), one.clone()]);
+        let a0_zerofier = Polynomial::new(&[-one, one]);
         // P_1(x) = (x - w^1)
-        let a1_zerofier = Polynomial::new(&[-primitive_root.pow(1u32), one.clone()]);
+        let a1_zerofier = Polynomial::new(&[-primitive_root.pow(1u32), one]);
         // P_res(x) = (x - w^7)
         let res_zerofier = Polynomial::new(&[-primitive_root.pow(7u32), one]);
 


### PR DESCRIPTION
Bump Lambdaworks to the latest version with Wasm support

Since now FiniteFields implements copy:

- Add clippy ignore for op_ref, since we want to avoid copying them
- Removed unnecessary clones 