### PR TITLE
Disable cache for Lambda Mac

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,9 +139,6 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Set up cargo cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Install gmp
         run: brew install gmp
 


### PR DESCRIPTION
This is using LambdaClass internet connection to donwnload the cache, which is slow and fails sometimes. We should disable this to not bloat lambda's network