### PR TITLE
Add security bits to benchmarks

### DIFF
--- a/benches/criterion_prover.rs
+++ b/benches/criterion_prover.rs
@@ -32,11 +32,6 @@ fn cairo_benches(c: &mut Criterion) {
         "fibonacci/1000",
         &cairo0_program_path("fibonacci_1000.json"),
     );
-    run_cairo_bench(
-        &mut group,
-        "fibonacci/10000",
-        &cairo0_program_path("fibonacci_10000.json"),
-    );
 }
 
 fn cairo0_program_path(program_name: &str) -> String {

--- a/benches/criterion_prover.rs
+++ b/benches/criterion_prover.rs
@@ -6,7 +6,7 @@ use lambdaworks_stark::{
         air::generate_cairo_proof,
         runner::run::{generate_prover_args, CairoVersion},
     },
-    starks::proof::options::ProofOptions,
+    starks::proof::options::{ProofOptions, SecurityLevel},
 };
 use std::time::Duration;
 
@@ -32,6 +32,11 @@ fn cairo_benches(c: &mut Criterion) {
         "fibonacci/1000",
         &cairo0_program_path("fibonacci_1000.json"),
     );
+    run_cairo_bench(
+        &mut group,
+        "fibonacci/10000",
+        &cairo0_program_path("fibonacci_10000.json"),
+    );
 }
 
 fn cairo0_program_path(program_name: &str) -> String {
@@ -43,7 +48,7 @@ fn cairo0_program_path(program_name: &str) -> String {
 
 fn run_cairo_bench(group: &mut BenchmarkGroup<'_, WallTime>, benchname: &str, program_path: &str) {
     let program_content = std::fs::read(program_path).unwrap();
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::new_secure(SecurityLevel::Provable80Bits, 3);
     let (main_trace, pub_inputs) =
         generate_prover_args(&program_content, &CairoVersion::V0, &None).unwrap();
 

--- a/benches/criterion_verifier.rs
+++ b/benches/criterion_verifier.rs
@@ -6,7 +6,10 @@ use lambdaworks_math::{
 };
 use lambdaworks_stark::{
     cairo::air::{verify_cairo_proof, PublicInputs},
-    starks::proof::{options::ProofOptions, stark::StarkProof},
+    starks::proof::{
+        options::{ProofOptions, SecurityLevel},
+        stark::StarkProof,
+    },
 };
 use std::time::Duration;
 
@@ -45,6 +48,11 @@ fn verifier_benches(c: &mut Criterion) {
         "fibonacci/1000",
         &cairo0_proof_path("fibonacci_1000.proof"),
     );
+    run_verifier_bench(
+        &mut group,
+        "fibonacci/10000",
+        &cairo0_proof_path("fibonacci_10000.proof"),
+    );
 }
 
 fn cairo0_proof_path(program_name: &str) -> String {
@@ -60,7 +68,7 @@ fn run_verifier_bench(
     program_path: &str,
 ) {
     let (proof, pub_inputs) = load_proof_and_pub_inputs(program_path);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::new_secure(SecurityLevel::Provable80Bits, 3);
     group.bench_function(benchname, |bench| {
         bench.iter(|| black_box(verify_cairo_proof(&proof, &pub_inputs, &proof_options)));
     });

--- a/benches/criterion_verifier.rs
+++ b/benches/criterion_verifier.rs
@@ -48,11 +48,6 @@ fn verifier_benches(c: &mut Criterion) {
         "fibonacci/1000",
         &cairo0_proof_path("fibonacci_1000.proof"),
     );
-    run_verifier_bench(
-        &mut group,
-        "fibonacci/10000",
-        &cairo0_proof_path("fibonacci_10000.proof"),
-    );
 }
 
 fn cairo0_proof_path(program_name: &str) -> String {


### PR DESCRIPTION
The benchmarks are now run with provable security level of 80 bits.