### PR TITLE
Parallelize constraint evaluator

### DIFF
--- a/src/starks/prover.rs
+++ b/src/starks/prover.rs
@@ -231,7 +231,8 @@ fn round_2_compute_composition_polynomial<F, A>(
 ) -> Round2<F>
 where
     F: IsFFTField,
-    A: AIR<Field = F> + Sync,
+    A: AIR<Field = F> + Send + Sync,
+    A::RAPChallenges: Send + Sync,
     FieldElement<F>: ByteConversion + Send + Sync,
 {
     // Create evaluation table
@@ -529,7 +530,8 @@ pub fn prove<F, A>(
 ) -> Result<StarkProof<F>, ProvingError>
 where
     F: IsFFTField,
-    A: AIR<Field = F> + Sync,
+    A: AIR<Field = F> + Send + Sync,
+    A::RAPChallenges: Send + Sync,
     FieldElement<F>: ByteConversion + Send + Sync,
 {
     info!("Started proof generation...");


### PR DESCRIPTION
I've run the benchmarks with the rayon threadpool configured to use 8 threads on:

- An Apple M1 with 4 E and 4 P cores. With this configuration, this PR improves the performance of the prover by 18% for fibo 500 and 17% for fibo 1k.
- An Intel Xeon Platinum with 4 cores. With this configuration, this PR improves the performance of the prover by 16% for fibo 500 and 15% for fibo 1k.